### PR TITLE
fix(spec): `display_name` is not a required property on `joined_members`

### DIFF
--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1354,7 +1354,7 @@ class Schemas:
                             "avatar_url": {"type": ["string", "null"]},
                             "display_name": {"type": ["string", "null"]},
                         },
-                        "required": ["display_name"],
+                        "required": [],
                     }
                 },
             }


### PR DESCRIPTION
Source: https://spec.matrix.org/v1.9/client-server-api/#get_matrixclientv3roomsroomidjoined_members

Note that it's not required.

This was encountered in the wild on the conduit.rs implementation.

Credit to @CobaltCause from conduit.rs to accompany me on this journey.