### PR TITLE
fix(spec): `failures` is not a required property for E2EE APIs

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1324,7 +1324,7 @@ class KeysQueryResponse(Response):
     def from_dict(cls, parsed_dict: Dict[Any, Any]):
         # type: (...) -> Union[KeysQueryResponse, ErrorResponse]
         device_keys = parsed_dict["device_keys"]
-        failures = parsed_dict["failures"]
+        failures = parsed_dict.get("failures", {})
 
         return cls(device_keys, failures)
 
@@ -1344,7 +1344,7 @@ class KeysClaimResponse(Response):
     ):
         # type: (...) -> Union[KeysClaimResponse, ErrorResponse]
         one_time_keys = parsed_dict["one_time_keys"]
-        failures = parsed_dict["failures"]
+        failures = parsed_dict.get("failures", {})
 
         return cls(one_time_keys, failures, room_id)
 

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1242,7 +1242,7 @@ class Schemas:
             },
             "failures": {"type": "object"},
         },
-        "required": ["device_keys", "failures"],
+        "required": ["device_keys"],
     }
 
     keys_claim = {
@@ -1287,7 +1287,7 @@ class Schemas:
             },
             "failures": {"type": "object"},
         },
-        "required": ["one_time_keys", "failures"],
+        "required": ["one_time_keys"],
     }
 
     devices = {


### PR DESCRIPTION
Sources:

- https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3keysclaim
- https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3keysquery

Notice that "Required" is not here for `failures`.

This was encountered in the wild with conduit.rs implementation.

Credit to @CobaltCause for accompanying me on this journey.