### PR TITLE
feat(debug): enable debugging of invalid bodies

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -221,6 +221,8 @@ from ..responses import (
 from . import Client, ClientConfig
 from .base_client import logged_in, store_loaded
 
+import logging
+
 _ShareGroupSessionT = Union[ShareGroupSessionError, ShareGroupSessionResponse]
 
 _ProfileGetDisplayNameT = Union[
@@ -240,6 +242,7 @@ SynchronousFile = (
 )
 AsyncFile = (AsyncBufferedReader, AsyncTextIOWrapper)
 
+logger = logging.getLogger(__name__)
 
 @dataclass
 class ResponseCb:
@@ -475,7 +478,10 @@ class AsyncClient(Client):
             try:
                 # matrix.org return an incorrect content-type for .well-known
                 # API requests, which leads to .text() working but not .json()
-                return json.loads(await transport_response.text())
+                contents = await transport_response.text()
+                logger.debug("During body parsing, failed to parse the JSON, dumping the text representation on the next log")
+                logger.debug("%s", contents)
+                return json.loads(contents)
             except (JSONDecodeError, ContentTypeError):
                 pass
 


### PR DESCRIPTION
Sometimes, a non-compliant server may send invalid bodies, how to debug that can be arbitrarily hard because of an environment not enabling you to exploit `SSLKEYLOGFILE` or similar technique to decrypt the TLS traffic.

This is a cheap way to dump it.

I don't care too much about this PR being unmerged, I put it here for other people as it was useful for me.