### PR TITLE
fix(spec): `RoomContext` has no required field theoretically

### DIFF
--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1841,8 +1841,12 @@ class RoomContextResponse(Response):
         parsed_dict: Dict[Any, Any],
         room_id: str,
     ) -> Union[RoomContextResponse, ErrorResponse]:
-        events_before = SyncResponse._get_room_events(parsed_dict.get("events_before", []))
-        events_after = SyncResponse._get_room_events(parsed_dict.get("events_after", []))
+        events_before = SyncResponse._get_room_events(
+            parsed_dict.get("events_before", [])
+        )
+        events_after = SyncResponse._get_room_events(
+            parsed_dict.get("events_after", [])
+        )
         event = Event.parse_event(parsed_dict["event"])
 
         state = SyncResponse._get_room_events(parsed_dict.get("state", {}))

--- a/nio/responses.py
+++ b/nio/responses.py
@@ -1771,8 +1771,8 @@ class RoomContextResponse(Response):
 
     room_id: str = field()
 
-    start: str = field()
-    end: str = field()
+    start: Optional[str] = field()
+    end: Optional[str] = field()
 
     event: Optional[Union[Event, BadEventType]] = field()
 
@@ -1788,16 +1788,16 @@ class RoomContextResponse(Response):
         parsed_dict: Dict[Any, Any],
         room_id: str,
     ) -> Union[RoomContextResponse, ErrorResponse]:
-        events_before = SyncResponse._get_room_events(parsed_dict["events_before"])
-        events_after = SyncResponse._get_room_events(parsed_dict["events_after"])
+        events_before = SyncResponse._get_room_events(parsed_dict.get("events_before", []))
+        events_after = SyncResponse._get_room_events(parsed_dict.get("events_after", []))
         event = Event.parse_event(parsed_dict["event"])
 
-        state = SyncResponse._get_room_events(parsed_dict["state"])
+        state = SyncResponse._get_room_events(parsed_dict.get("state", {}))
 
         return cls(
             room_id,
-            parsed_dict["start"],
-            parsed_dict["end"],
+            parsed_dict.get("start"),
+            parsed_dict.get("end"),
             event,
             events_before,
             events_after,

--- a/nio/schemas.py
+++ b/nio/schemas.py
@@ -1194,14 +1194,9 @@ class Schemas:
             "events_after": {"type": "array"},
             "event": {"type": "object"},
         },
-        "required": [
-            "start",
-            "end",
-            "state",
-            "events_before",
-            "events_after",
-            "event",
-        ],
+        # As per https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
+        # Everything _SHOULD_ be optional *but* `event` is so necessary that we still put it as required.
+        "required": ["event"],
     }
 
     invite_event = {


### PR DESCRIPTION
As per https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidcontexteventid.
No field is required, we still keep `event` required because it happens to be the true required one.

Seen in the wild with conduit.rs.