### PR TITLE
Fix #432 - Properly pass JSON content to DownloadResponse

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -533,8 +533,10 @@ class AsyncClient(Client):
             name = transport_response.content_disposition.filename
 
         if issubclass(response_class, FileResponse) and is_json:
-            parsed_dict = await self.parse_body(transport_response)
-            resp = response_class.from_data(parsed_dict, content_type, name)
+            data = await transport_response.read()
+            # Data should NOT be parsed when passing to DownloadResponse,
+            # otherwise it will be parsed as an error!
+            resp = response_class.from_data(data, content_type, name)
 
         elif issubclass(response_class, FileResponse):
             if not save_to:


### PR DESCRIPTION
Should, fingers crossed, close #432.

This has been tested using the bot used to repro the original issue.

---

The issue came from the fact that, even after knowing the response content was expected to be application/json, it was *parsed* - `from_dict` then expected bytes or a path for the real content, however it received a json object (be that dictionary, array, integer, null, string, so on).
If it was given a dictionary, it'd assume it was an error response from the homeserver, and naively treat it as such.
If it was given anything else, it'd become confused and return an "invalid data" error.

This patch fixes this by simply __not parsing__ the response (as, from what I can tell, its not supposed to be parsed in this situation).

Edits, fixes, and changes welcome.