### PR TITLE
Add `stop_sync_forever` method, to gracefully exit `sync_forever` loop.

### DIFF
--- a/nio/client/async_client.py
+++ b/nio/client/async_client.py
@@ -448,6 +448,9 @@ class AsyncClient(Client):
 
         self.config: AsyncClientConfig = config or AsyncClientConfig()
 
+        # The flag used to gracefully stop `sync_forever`.
+        self._stop_sync_forever = False
+
         super().__init__(user, device_id, store_path, self.config)
 
     def add_response_callback(
@@ -1319,8 +1322,9 @@ class AsyncClient(Client):
         """
 
         first_sync = True
+        self._stop_sync_forever = False
 
-        while True:
+        while not self._stop_sync_forever:
             try:
                 use_filter = (
                     first_sync_filter
@@ -1383,6 +1387,14 @@ class AsyncClient(Client):
                     task.cancel()
 
                 raise
+
+    def stop_sync_forever(self):
+        """Request that the `sync_forever` loop exits gracefully.
+
+        If a `sync_forever` function is running, it will finish its sync loop and exit, leaving this `AsyncClient` in
+        a consistent state. In particular, it will be possible to run `sync_forever` again at a later point.
+        """
+        self._stop_sync_forever = True
 
     @logged_in_async
     @store_loaded


### PR DESCRIPTION
This change adds a method to request that `sync_forever` main loop exits gracefully.

Examples use `Task.cancel` for this purpose, but I am concerned that canceling an async task may result in an inconsistent state, especially with anything concerning encryption. Using the new method will ensure that the latest sync response is fully processed by our `AsyncClient` before the sync loop exits.