### PR TITLE
Replace m2r2 by sphinx_mdinclude

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
-    "m2r2",
+    "sphinx_mdinclude",
     "sphinx_autodoc_typehints",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ docs = [
     "setuptools>=61.0",
     "sphinx~=7.4",
     "sphinx-autodoc-typehints~=2.1",
-    "m2r2~=0.3",
+    "sphinx_mdinclude>=0.5",
     "sphinx_rtd_theme~=2.0",
 ]
 


### PR DESCRIPTION
> `m2r2` is a fork of `m2r` and both are more or less unmaintained. This replaces it by `sphinx_mdinclude` which is maintained.
