### PR TITLE
(fix #520) utilise the old media path for uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ doc/html
 *.swp
 build
 .idea/
+.venv/
+venv/

--- a/src/nio/api.py
+++ b/src/nio/api.py
@@ -1614,7 +1614,9 @@ class Api:
         if filename:
             query_parameters["filename"] = filename
 
-        return "POST", Api._build_path(path, query_parameters, MATRIX_LEGACY_MEDIA_API_PATH)
+        return "POST", Api._build_path(
+            path, query_parameters, MATRIX_LEGACY_MEDIA_API_PATH
+        )
 
     @staticmethod
     def download(

--- a/src/nio/api.py
+++ b/src/nio/api.py
@@ -54,6 +54,7 @@ except ImportError:
 MATRIX_API_PATH_V1: str = "/_matrix/client/v1"
 MATRIX_API_PATH_V3: str = "/_matrix/client/v3"
 MATRIX_MEDIA_API_PATH: str = "/_matrix/client/v1/media"
+MATRIX_LEGACY_MEDIA_API_PATH: str = "/_matrix/media/v3"
 
 _FilterT = Union[None, str, Dict[Any, Any]]
 
@@ -1613,7 +1614,7 @@ class Api:
         if filename:
             query_parameters["filename"] = filename
 
-        return "POST", Api._build_path(path, query_parameters, MATRIX_MEDIA_API_PATH)
+        return "POST", Api._build_path(path, query_parameters, MATRIX_LEGACY_MEDIA_API_PATH)
 
     @staticmethod
     def download(

--- a/tests/async_client_test.py
+++ b/tests/async_client_test.py
@@ -131,6 +131,7 @@ from nio import (
 from nio.api import (
     MATRIX_API_PATH_V1,
     MATRIX_API_PATH_V3,
+    MATRIX_LEGACY_MEDIA_API_PATH,
     MATRIX_MEDIA_API_PATH,
     EventFormat,
     RelationshipType,
@@ -146,6 +147,7 @@ from nio.responses import PublicRoom, PublicRoomsResponse
 BASE_URL_V1 = f"https://example.org{MATRIX_API_PATH_V1}"
 BASE_URL_V3 = f"https://example.org{MATRIX_API_PATH_V3}"
 BASE_MEDIA_URL = f"https://example.org{MATRIX_MEDIA_API_PATH}"
+BASE_LEGACY_MEDIA_URL = f"https://example.org{MATRIX_LEGACY_MEDIA_API_PATH}"
 TEST_ROOM_ID = "!testroom:example.org"
 
 ALICE_ID = "@alice:example.org"
@@ -1874,7 +1876,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.png",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -1908,7 +1910,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.png",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -1955,7 +1957,7 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.py",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.py",
             status=200,
             payload=self.upload_response,
             repeat=True,
@@ -2005,13 +2007,13 @@ class TestClass:
         # We make sure to read the data in the first post response to verify
         # that we can read the full file in a subsequent post.
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.py",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.py",
             status=429,
             payload=self.limit_exceeded_error_response,
             callback=check_content,
         )
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.py",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.py",
             status=200,
             payload=self.upload_response,
             callback=check_content,
@@ -2042,13 +2044,13 @@ class TestClass:
         monitor = TransferMonitor(filesize)
 
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.png",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.png",
             status=429,
             payload=self.limit_exceeded_error_response,
         )
 
         aioresponse.post(
-            f"{BASE_MEDIA_URL}/upload?&filename=test.png",
+            f"{BASE_LEGACY_MEDIA_URL}/upload?&filename=test.png",
             status=200,
             payload=self.upload_response,
             repeat=True,


### PR DESCRIPTION
Media uploads still make use of `/_matrix/media/v3/upload`, and this was not caught before #520 was merged, meaning that as of nio 0.25.1, media uploads cannot be performed.

This change simply reverts part of 520 by replacing the upload build_path call with the old media endpoint.