### PR TITLE
Drop dependency atomicwrites

### DIFF
--- a/contrib/archlinux/pkgbuild/PKGBUILD.git
+++ b/contrib/archlinux/pkgbuild/PKGBUILD.git
@@ -15,7 +15,7 @@ conflicts=('python-matrix-nio')
 provides=('python-matrix-nio')
 depends=('python' 'python-olm' 'python-h11' 'python-h2'
        'python-jsonschema' 'python-logbook'
-       'python-peewee' 'python-atomicwrites'
+       'python-peewee'
        'python-pycryptodome' 'python-unpaddedbase64')
 checkdepends=()
 source=("$pkgbase-$pkgver.tar.gz")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
 
 [project.optional-dependencies]
 e2e = [
-    "atomicwrites~=1.4",
     "cachetools>=5.3",
     "peewee~=3.14",
     "vodozemac>=0.9.0.post2",

--- a/src/nio/crypto/key_export.py
+++ b/src/nio/crypto/key_export.py
@@ -10,13 +10,14 @@
 # limitations under the License.
 from pathlib import Path
 
-from atomicwrites import atomic_write
 from Crypto import Random
 from Crypto.Cipher import AES
 from Crypto.Hash import HMAC, SHA256, SHA512
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Util import Counter
 from unpaddedbase64 import decode_base64, encode_base64
+
+from ..util import atomic_write
 
 HEADER = "-----BEGIN MEGOLM SESSION DATA-----"
 FOOTER = "-----END MEGOLM SESSION DATA-----"

--- a/src/nio/store/file_trustdb.py
+++ b/src/nio/store/file_trustdb.py
@@ -4,10 +4,9 @@ from collections.abc import Iterator
 from functools import wraps
 from typing import Any
 
-from atomicwrites import atomic_write
-
 from ..crypto import OlmDevice
 from ..exceptions import OlmTrustError
+from ..util import atomic_write
 from . import logger
 
 

--- a/src/nio/util.py
+++ b/src/nio/util.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TextIO
+
+
+@contextmanager
+def atomic_write(path: str | os.PathLike, overwrite: bool = False) -> Iterator[TextIO]:
+    """Atomically write a file.
+
+    The data is written to a temporary file in the same directory as
+    ``path``, synced to disk, and then moved to ``path``, so a partially
+    written file is never visible.
+
+    :param path: Path of the destination file.
+    :param overwrite: Whether to replace an existing file. If False, a
+        ``FileExistsError`` is raised if the file already exists.
+
+    :returns: Text file object to which data can be written.
+    """
+    directory = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=directory)
+    os.close(fd)
+
+    try:
+        with open(tmp_path, "w") as f:
+            yield f
+            f.flush()
+            os.fsync(f.fileno())
+
+        if overwrite:
+            os.replace(tmp_path, path)
+        else:
+            # link() fails if the target exists, making the check-and-move atomic.
+            os.link(tmp_path, path)
+            os.unlink(tmp_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/uv.lock
+++ b/uv.lock
@@ -262,12 +262,6 @@ wheels = [
 ]
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11", size = 14227, upload-time = "2022-07-08T18:31:40.459Z" }
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,7 +1086,6 @@ docs = [
     { name = "sphinx-rtd-theme" },
 ]
 e2e = [
-    { name = "atomicwrites" },
     { name = "cachetools" },
     { name = "peewee" },
     { name = "vodozemac" },
@@ -1121,7 +1114,6 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1" },
     { name = "aiohttp", specifier = ">=3.10" },
     { name = "aiohttp-socks", specifier = ">=0.8" },
-    { name = "atomicwrites", marker = "extra == 'e2e'", specifier = "~=1.4" },
     { name = "cachetools", marker = "extra == 'e2e'", specifier = ">=5.3" },
     { name = "h11", specifier = ">=0.14" },
     { name = "h2", specifier = ">=4.0" },


### PR DESCRIPTION
atomicwrites is unmaintained upstream. It was originally written at a time when the stdlib didn't provide facilities to easily implement its logic. Nowadays, implementing it is relatively simple.

Use an in-tree function which covers our use case specifically.